### PR TITLE
20260624-chore-exp-clone-and-branch-naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,9 @@ local/*
 
 integrations/*
 
+# Experiment repo (private), cloned as a nested git clone — never tracked here
+exp/
+
 # Per-developer agent context (machine-specific, not shared)
 CLAUDE.local.md
 # Sphinx autosummary output (regenerated on build)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ are in **[docs/conventions.md](docs/conventions.md)**. The essentials:
 - **Tests:** mirror the source tree under `tests/`; `test_*.py`, `TestThing` classes, `test_behaviour` methods.
 - **Reuse first:** prefer existing abstractions (`LearningMachine`, `IO`, `State`, `StepTheta`/`StepX`,
   `zenkai.utils`) over re-implementing — see the guardrails in [docs/conventions.md](docs/conventions.md).
+- **Branches & PRs:** name them `YYYYMMDD-<fix|imp|chore>-<slug>` (e.g. `20260624-chore-exp-clone`). The
+  date prefix keeps work chronologically organized; `<slug>` is a short kebab-case description.
 
 ## Specs
 


### PR DESCRIPTION
## What

Two small chore/docs changes:

1. **Ignore `exp/`** — the private `zenkai-exp` repo is cloned into `exp/` as a plain nested git clone (not a tracked submodule, which would leak its name/URL via `.gitmodules`). Add `exp/` to `.gitignore` so its contents are never tracked by the public `zenkai` repo.
2. **Branch/PR naming convention** — document `YYYYMMDD-<fix|imp|chore>-<slug>` under Conventions in `CLAUDE.md` so work stays chronologically organized.

## Why

Keeps the public repo clean of the private experiment repo, and gives branches/PRs a consistent, date-ordered naming scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)