### PR TITLE
fix(lm): correct FA/DFA grad transfer and OutT regressions

### DIFF
--- a/tests/lm/test_feedback_alignment.py
+++ b/tests/lm/test_feedback_alignment.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 from zenkai._core import State, iou
 from zenkai._core._params import params_get
-from zenkai.lm import _feedback_alignment
+from zenkai.lm import LMode, OutT, _feedback_alignment, set_lmode
 from zenkai.optimz import OptimFactory
 
 
@@ -172,3 +172,160 @@ class TestDFALearner:
         learner.accumulate(x, t, state)
         x_prime = learner.step_x(x, t, state)
         assert (x_prime.f != x.f).any()
+
+
+class TestFeedbackAlignmentLearns:
+    """Regression: FA/DFA must actually *learn*.
+
+    A 2026-06 rewrite transferred netB's weight *values* into net.grad instead of netB's
+    *gradients*, so the parameter update was a constant (independent of the target) and loss
+    random-walked upward. The prior tests only checked that parameters changed, not that the
+    update used the target or that loss fell, so the bug slipped through.
+    """
+
+    def test_fa_grad_depends_on_target(self):
+        torch.manual_seed(0)
+        net = nn.Linear(8, 4)
+        learner = _feedback_alignment.FALearner(
+            net,
+            nn.Linear(8, 4),
+            optim_factory=OptimFactory("SGD", lr=1e-2),
+            activation=nn.Sigmoid(),
+            learn_criterion="MSELoss",
+        )
+        x = iou(torch.rand(16, 8))
+
+        def grad_for(target):
+            net.zero_grad()
+            state = State()
+            learner.forward_io(x, state)
+            learner.accumulate(x, iou(target), state)
+            return net.weight.grad.clone()
+
+        g1 = grad_for(torch.rand(16, 4))
+        g2 = grad_for(torch.rand(16, 4))
+        # the update must depend on the target (the bug made net.grad == netB's constant weights)
+        assert not torch.allclose(g1, g2)
+
+    def test_fa_reduces_loss(self):
+        torch.manual_seed(0)
+        net = nn.Linear(8, 4)
+        learner = _feedback_alignment.FALearner(
+            net,
+            nn.Linear(8, 4),
+            optim_factory=OptimFactory("SGD", lr=0.2),
+            activation=nn.Sigmoid(),
+            learn_criterion="MSELoss",
+        )
+        x = iou(torch.rand(32, 8))
+        t = iou(torch.rand(32, 4))
+
+        def loss():
+            return ((learner.forward_io(x, State()).f - t.f) ** 2).mean().item()
+
+        before = loss()
+        for _ in range(200):
+            state = State()
+            learner.forward_io(x, state)
+            learner.accumulate(x, t, state)
+            learner.step(x, t, state)
+        assert loss() < before
+
+    def test_dfa_grad_depends_on_target(self):
+        torch.manual_seed(0)
+        net = nn.Linear(8, 4)
+        learner = _feedback_alignment.DFALearner(
+            net,
+            nn.Linear(8, 4),
+            4,
+            4,
+            optim_factory=OptimFactory("SGD", lr=1e-2),
+            activation=nn.Sigmoid(),
+            learn_criterion="MSELoss",
+        )
+        x = iou(torch.rand(16, 8))
+
+        def grad_for(target):
+            net.zero_grad()
+            state = State()
+            _, out_t = learner.forward_io(x, state)
+            out_t.t = iou(target)
+            learner.accumulate(x, iou(target), state)
+            return net.weight.grad.clone()
+
+        g1 = grad_for(torch.rand(16, 4))
+        g2 = grad_for(torch.rand(16, 4))
+        assert not torch.allclose(g1, g2)
+
+    def test_dfa_reduces_loss(self):
+        torch.manual_seed(0)
+        net = nn.Linear(8, 4)
+        learner = _feedback_alignment.DFALearner(
+            net,
+            nn.Linear(8, 4),
+            4,
+            4,
+            optim_factory=OptimFactory("SGD", lr=0.2),
+            activation=nn.Sigmoid(),
+            learn_criterion="MSELoss",
+        )
+        x = iou(torch.rand(32, 8))
+        t = iou(torch.rand(32, 4))
+
+        def loss():
+            y, _ = learner.forward_io(x, State())
+            return ((learner.B(y) - t.f) ** 2).mean().item()
+
+        before = loss()
+        for _ in range(200):
+            state = State()
+            _, out_t = learner.forward_io(x, state)
+            out_t.t = t
+            learner.accumulate(x, t, state)
+            learner.step(x, t, state)
+        assert loss() < before
+
+
+class TestOutTAutograd:
+    """Regression: OutT must work as an nn.Module so DFA can be driven via autograd.
+
+    A 2026-06 reorg dropped ``super().__init__()`` (so OutT couldn't be called) and mangled the
+    forward arg handling (``apply(self, x)`` + returning the tuple), so the autograd-driven DFA
+    path was dead. The manual ``out_t.t = ...`` path hid it because it never calls the module.
+    """
+
+    def test_outt_callable_passthrough_and_sets_target(self):
+        ot = OutT()
+        y = torch.rand(4, 3, requires_grad=True)
+        z = ot(y)  # must be callable and return the tensor (not a tuple)
+        assert torch.is_tensor(z) and torch.equal(z, y)
+        z.sum().backward()
+        assert ot.t is not None  # backward deposits the target
+
+    def test_dfa_learns_via_autograd_outt(self):
+        torch.manual_seed(0)
+        net = nn.Linear(8, 4)
+        learner = _feedback_alignment.DFALearner(
+            net,
+            nn.Linear(8, 4),
+            4,
+            4,
+            optim_factory=OptimFactory("SGD", lr=0.1),
+            activation=nn.Sigmoid(),
+            learn_criterion="MSELoss",
+        )
+        set_lmode(learner, LMode.WithStep)
+        x = torch.rand(32, 8)
+        t = torch.rand(32, 4)
+
+        def local_loss():  # DFA optimizes ||B(y) - t||^2
+            with torch.no_grad():
+                y, _ = learner(x)
+                return ((learner.B(y) - t) ** 2).mean().item()
+
+        before = local_loss()
+        for _ in range(200):
+            y, out_t = learner(x)  # forward -> (output, OutT placeholder)
+            z = out_t(y)  # wire OutT into the graph
+            (0.5 * ((z - t) ** 2).sum()).backward()  # backward sets out_t.t; accumulate/step run
+        assert local_loss() < before

--- a/zenkai/lm/_feedback_alignment.py
+++ b/zenkai/lm/_feedback_alignment.py
@@ -1,3 +1,26 @@
+"""Feedback-alignment learners — ``FALearner`` and ``DFALearner``.
+
+These train a layer *without weight transport*: the forward weights are updated using a fixed
+**random** feedback path instead of their own transpose. They fit zenkai's model where a
+``LearningMachine`` receives a **target** and the backward pass carries targets (not just
+gradients) — feedback alignment is one way to produce that target.
+
+- **FA** (``FALearner``): the error is routed to the layer through a fixed random net ``netB``
+  (used to assign credit to the input via ``step_x``); the weight update is still ``delta @ x.T``.
+- **DFA** (``DFALearner``): each layer regresses a fixed random readout ``B(y)`` of its own output
+  onto the **global** output target, so the learning signal reaches every layer *directly*
+  (bypassing the layer-by-layer chain). The global target arrives through an ``OutT`` placeholder.
+
+Both can be driven two ways (see the class docstrings for runnable examples):
+
+- **autograd** — ``set_lmode(m, LMode.WithStep)`` then ``loss.backward()`` (FA: a plain MSE loop;
+  DFA: wire the returned ``OutT`` into the loss so the backward deposits the global target);
+- **manual** — ``forward_io`` -> (DFA: ``out_t.t = target``) -> ``accumulate`` -> ``step``.
+
+Use the **1/2-SSE** criterion (``NNLoss("MSELoss", "sum", 0.5)``) so the target scale is right at
+every layer; with ``mean`` the per-layer signal is divided down and hidden layers barely move.
+"""
+
 # 1st party
 import typing
 
@@ -32,7 +55,36 @@ def fa_target(y: IO, y_prime: IO, detach: bool = True) -> IO:
 
 
 class FALearner(GradLearner):
-    """Learner for implementing feedback alignment."""
+    """Feedback alignment for a single layer.
+
+    Wraps a forward module ``net`` and a same-shaped, fixed-random ``netB``. The weight update is
+    the true ``delta @ x.T``; ``netB`` only shapes the input's target in ``step_x`` (random feedback
+    instead of ``net``'s transpose), so a single layer trains like backprop and the randomness only
+    matters once layers are stacked.
+
+    Example:
+        Autograd loop (set ``WithStep`` so ``step`` runs; ``net``/``netB`` default lmode is
+        ``Standard``, which would skip the parameter update)::
+
+            from zenkai.lm import FALearner, LMode, set_lmode
+            from zenkai.optimz import OptimFactory
+
+            net, netB = nn.Linear(8, 4), nn.Linear(8, 4)
+            fa = FALearner(net, netB, activation=nn.Sigmoid(),
+                           optim_factory=OptimFactory("SGD", lr=0.3))
+            set_lmode(fa, LMode.WithStep)
+            for x, t in loader:                       # x, t are tensors
+                y = fa(x)
+                (0.5 * ((y - t) ** 2).sum()).backward()   # 1/2-SSE: target = y - grad
+
+        Or drive it manually::
+
+            from zenkai import State, iou
+            state = State()
+            fa.forward_io(iou(x), state)
+            fa.accumulate(iou(x), iou(t), state)
+            fa.step(iou(x), iou(t), state)
+    """
 
     def __init__(
         self,
@@ -94,7 +146,10 @@ class FALearner(GradLearner):
         self.criterion.assess(y, t).backward()
         y_det = state._y_det
         y2.backward(y_det.grad)
-        param_utils.p_transfer(self.net, self.netB, lambda p1, p2: param_utils.grad_set(p1, p2))
+        # Feedback alignment: net's weight gradient is (delta @ x.T). Because netB(x) shares the
+        # same input x, netB's *gradient* already equals that desired delta @ x.T, so we copy
+        # netB's GRADIENT (p2.grad) onto net's params -- NOT netB's weight values (p2).
+        param_utils.p_transfer(self.net, self.netB, lambda p1, p2: param_utils.grad_set(p1, p2.grad))
 
     def step(self, x: IO, t: IO, state: State):
         """Step and zero the gradients.
@@ -110,7 +165,41 @@ class FALearner(GradLearner):
 
 
 class DFALearner(GradLearner):
-    """Learner for implementing direct feedback alignment."""
+    """Direct feedback alignment for a single layer.
+
+    Like :class:`FALearner`, but the layer regresses a fixed random readout ``B(y)`` of its output
+    (``B: out_features -> t_features``) onto the **global** output target, so the learning signal
+    comes straight from the output error rather than relayed through the layers above. The global
+    target is supplied through the ``OutT`` placeholder returned by the forward pass.
+
+    Note:
+        When stacking these into a network, set the **output** layer's ``B`` to the identity
+        (``layer.B.weight.copy_(torch.eye(t_features))``) so the network output lives in target
+        space and ``argmax(y)`` is the prediction; hidden layers keep their random ``B``.
+
+    Example:
+        Autograd: the forward returns ``(output, OutT)``; wire the ``OutT`` into the loss so the
+        backward pass deposits the global target into the layer::
+
+            from zenkai.lm import DFALearner, LMode, set_lmode
+            from zenkai.optimz import OptimFactory
+
+            dfa = DFALearner(nn.Linear(8, 4), nn.Linear(8, 4), out_features=4, t_features=4,
+                             optim_factory=OptimFactory("SGD", lr=0.1), activation=nn.Sigmoid())
+            set_lmode(dfa, LMode.WithStep)
+            y, out_t = dfa(x)
+            z = out_t(y)                                  # wire OutT -> backward sets out_t.t
+            (0.5 * ((z - t) ** 2).sum()).backward()
+
+        Or manually (set the global target explicitly)::
+
+            from zenkai import State, iou
+            state = State()
+            _, out_t = dfa.forward_io(iou(x), state)
+            out_t.t = iou(t)
+            dfa.accumulate(iou(x), iou(t), state)
+            dfa.step(iou(x), iou(t), state)
+    """
 
     def __init__(
         self,
@@ -186,7 +275,10 @@ class DFALearner(GradLearner):
         self.criterion(iou(y), state.out_t.t).backward()
         y2.backward(y_det.grad)
 
-        param_utils.p_transfer(self.net, self.netB, lambda p1, p2: param_utils.grad_set(p1, p2))
+        # Feedback alignment: net's weight gradient is (delta @ x.T). Because netB(x) shares the
+        # same input x, netB's *gradient* already equals that desired delta @ x.T, so we copy
+        # netB's GRADIENT (p2.grad) onto net's params -- NOT netB's weight values (p2).
+        param_utils.p_transfer(self.net, self.netB, lambda p1, p2: param_utils.grad_set(p1, p2.grad))
         assert x.f.grad is not None
 
     @forward_dep("_y")

--- a/zenkai/lm/_lm.py
+++ b/zenkai/lm/_lm.py
@@ -108,7 +108,7 @@ class _OutT(torch.autograd.Function):
         if len(x) == 0:
             return None
         if len(x) == 1:
-            return x
+            return x[0]
         return x
 
     @staticmethod
@@ -121,7 +121,18 @@ class _OutT(torch.autograd.Function):
 
 
 class OutT(nn.Module):
-    """Use to store the value to set T to be"""
+    """A placeholder that carries an output target into a learner.
+
+    Used by direct feedback alignment (:class:`~zenkai.lm.DFALearner`) so a layer can be trained
+    against the **global** output target. There are two ways to populate ``.t``:
+
+    - **autograd**: call it on the network output and put the result in your loss
+      (``z = out_t(y); loss = 1/2 * ((z - t) ** 2).sum(); loss.backward()``). It is an identity on
+      the forward pass; on the backward pass it stores ``t = output - grad`` into ``self.t`` before
+      the learner's ``accumulate`` runs.
+    - **manual**: set ``out_t.t = target`` directly (an :class:`~zenkai.IO`), then call
+      ``accumulate``/``step`` yourself.
+    """
 
     def __init__(self, t: IO = None):
         """Initialize a module that will store a target to be defined later
@@ -129,6 +140,7 @@ class OutT(nn.Module):
         Args:
             t (IO, optional): The target. Defaults to None.
         """
+        super().__init__()
         self.t = t
 
     def forward(self, *x: torch.Tensor):
@@ -141,7 +153,7 @@ class OutT(nn.Module):
         Returns:
             torch.Tensor: The output tensor after applying the forward pass.
         """
-        return _OutT.apply(self, x)
+        return _OutT.apply(self, *x)
 
 
 class LMode(Enum):
@@ -419,7 +431,20 @@ class LearningF(Function):
 
 
 class LearningMachine(nn.Module, ABC):
-    """A learning machine is a machine that updates its parameters based on an evaluation of its output."""
+    """A module that defines its own learning, not just its forward pass.
+
+    Beyond ``forward_nn`` (the computation) it implements how it learns: ``accumulate`` (stage an
+    update toward a target), ``step`` (apply it), and ``step_x`` (produce a target for its input, to
+    hand upstream). A machine receives a **target**, not a gradient.
+
+    zenkai reuses Torch autograd to carry those targets: calling ``.backward()`` on a loss enters a
+    custom ``Function`` that turns the output gradient into a target (``t = y - grad``) and then
+    dispatches the methods per :class:`LMode` (``WithStep`` = accumulate -> step_x -> step). Ordinary
+    backprop is the special case where the target is the gradient one and each layer minimises
+    ``1/2``-SSE to it; other learners (feedback alignment, least squares, evolutionary) just produce
+    the target a different way. Compose machines like ``nn.Module``s (``m2(m1(x))`` then
+    ``loss.backward()``) and ``step_x`` relays each target to the previous machine.
+    """
 
     def __init__(self, lmode: LMode = LMode.Standard):
         """Create a learning machine


### PR DESCRIPTION
Four regressions introduced by the package reorg, all invisible to the unit tests (which only
asserted that parameters *changed*). Found by actually training FALearner/DFALearner end-to-end.

## Fixes (`zenkai/lm/_feedback_alignment.py`, `zenkai/lm/_lm.py`)
1. **FA/DFA grad transfer** — `accumulate` copied netB's weight *values* into `net.grad` instead of
   netB's *gradients* (`grad_set(p1, p2)` → `p2.grad`). The update was target-independent (random),
   so FA/DFA never learned.
2. **`OutT` uncallable** — `OutT.__init__` missed `super().__init__()` (Torch requires it), so the
   autograd-driven DFA path crashed on call.
3. **`OutT.forward`** passed its args tuple as a single arg (`apply(self, x)` → `*x`).
4. **`_OutT.forward`** returned a tuple, not the tensor, for single input (`→ x[0]`).

## Tests (`tests/lm/test_feedback_alignment.py`)
New regression tests that would have caught all four: FA/DFA **reduce loss** and their update
**depends on the target**; `OutT` is **callable** and DFA **learns via the autograd loop**.

## Docs
`FALearner`, `DFALearner`, `OutT`, `LearningMachine` now have runnable examples and the correct
framing (a learner consumes a *target*; backprop is the special case).

Full suite: 405 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)